### PR TITLE
Set the dataGrid to readonly to fix GH-103

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,3 +11,4 @@
 # Please keep the list sorted.
 
 Geert van Horrik <geert@catenalogic.com>
+Nils Andresen <nils@nils-andresen.de>

--- a/src/RepositoryCleaner/Views/MainWindow.xaml
+++ b/src/RepositoryCleaner/Views/MainWindow.xaml
@@ -59,7 +59,7 @@
         </TextBox>
 
         <DataGrid x:Name="dataGrid" ItemsSource="{Binding FilteredRepositories}" AutoGenerateColumns="False"
-                  EnableRowVirtualization="False">
+                  IsReadOnly="True" EnableRowVirtualization="False">
             <DataGrid.Resources>
                 <Style TargetType="TextBlock" x:Key="MultiLineColumnViewStyle">
                     <Setter Property="TextWrapping" Value="Wrap" />


### PR DESCRIPTION
### Description of Change ###

`DataGrid` in `MainWindow` set to `IsReadOnly`

### Issues Resolved ### 

- fixes #103 

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- WPF

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Test is essentially the same, as described in #103 :
- Select repositories root
- click Analyze
- Double-Click in one of the cells in the grid
- No more crashes :-)

### PR Checklist ###

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [X] I am listed in the CONTRIBUTORS file
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
